### PR TITLE
Add tenant ID to Docker build and improve deployment configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -199,6 +199,7 @@ jobs:
           sudo docker build \
             --secret id=github_token,src=/tmp/github_token \
             --build-arg PORT=$PORT \
+            --build-arg TENANT_ID=$TENANT \
             -t mastra-test-dashboard:$ENV_FILE-latest \
             .
 
@@ -322,8 +323,18 @@ jobs:
               BASE_PATH=""
             fi
 
-            HEALTH_URL="http://localhost:3000${BASE_PATH}/api/health"
-            echo "🔍 Using health check URL: $HEALTH_URL"
+            # Set port based on tenant for health check
+            TENANT="${{ github.event.inputs.tenant }}"
+            if [ "$TENANT" = "fasthelp" ]; then
+              PORT=3001
+            elif [ "$TENANT" = "tusuzumi" ]; then
+              PORT=3002
+            else
+              PORT=3000
+            fi
+
+            HEALTH_URL="http://localhost:${PORT}${BASE_PATH}/api/health"
+            echo "🔍 Using health check URL: $HEALTH_URL (tenant: $TENANT, port: $PORT)"
 
             # Check container status
             echo "🔍 Container status:"
@@ -353,15 +364,32 @@ jobs:
 
               if [ "$CURRENT_IMAGE" != "none" ] && [ -n "$CURRENT_IMAGE" ]; then
                 echo "🔄 Restoring previous container with image: $CURRENT_IMAGE"
+
+                # Set port and base path based on tenant for rollback
+                TENANT="${{ github.event.inputs.tenant }}"
+                if [ "$TENANT" = "fasthelp" ]; then
+                  ROLLBACK_PORT=3001
+                  ROLLBACK_BASE_PATH="/fasthelp/dashboard"
+                elif [ "$TENANT" = "tusuzumi" ]; then
+                  ROLLBACK_PORT=3002
+                  ROLLBACK_BASE_PATH="/tusuzumi/dashboard"
+                else
+                  ROLLBACK_PORT=3000
+                  ROLLBACK_BASE_PATH="/dashboard"
+                fi
+
+                # Get registry IP for rollback
+                REGISTRY_IP=$(sudo docker inspect local-registry --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+
                 sudo docker run -d \
                   --name mastra-test-dashboard \
                   --network mastra-test-network \
                   --restart unless-stopped \
-                  -p $PORT:$PORT \
+                  -p $ROLLBACK_PORT:$ROLLBACK_PORT \
                   --env-file "/opt/mastra-test-dashboard/.env.$ENV_FILE" \
                   -e DATABASE_URL="postgresql://${{ vars.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@postgres-pgvector:5432/${{ vars.POSTGRES_DB }}" \
-                  -e TENANT_ID="${{ github.event.inputs.tenant }}" \
-                  -e NEXT_PUBLIC_BASE_PATH="$NEXT_PUBLIC_BASE_PATH" \
+                  -e TENANT_ID="$TENANT" \
+                  -e NEXT_PUBLIC_BASE_PATH="$ROLLBACK_BASE_PATH" \
                   $CURRENT_IMAGE
                 echo "🔄 Rollback completed"
               else

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,9 +80,11 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 USER nextjs
 
 ARG PORT=3000
+ARG TENANT_ID=default
 EXPOSE ${PORT}
 
 ENV PORT=${PORT}
+ENV TENANT_ID=${TENANT_ID}
 ENV HOSTNAME="0.0.0.0"
 
 # server.js is created by next build from the standalone output


### PR DESCRIPTION
## Summary
- Add `TENANT_ID` build argument to Dockerfile for better tenant isolation
- Pass tenant ID during Docker image build process
- Update health check to use tenant-specific ports (3000/3001/3002)
- Improve rollback logic with proper tenant configuration and port mapping
- Ensure correct port mapping for each tenant during deployment and rollback

## Changes
- **Dockerfile**: Added `TENANT_ID` build arg and environment variable
- **deploy.yml**: 
  - Added `--build-arg TENANT_ID=$TENANT` to Docker build command
  - Updated health check to detect tenant and use correct port
  - Enhanced rollback section with tenant-specific port and base path configuration

## Test plan
- [ ] Verify Docker build accepts TENANT_ID build argument
- [ ] Test health checks work on tenant-specific ports
- [ ] Verify deployment rollback uses correct tenant configuration
- [ ] Ensure container environment includes TENANT_ID variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>