### PR TITLE
Add tenant-specific Docker deployment improvements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ on:
         options:
           - default
           - fasthelp
-          - tusuzumi
+          - tsuzumi
 
 jobs:
   deploy:
@@ -85,7 +85,7 @@ jobs:
           TENANT="${{ github.event.inputs.tenant }}"
           if [ "$TENANT" = "fasthelp" ]; then
             PORT=3001
-          elif [ "$TENANT" = "tusuzumi" ]; then
+          elif [ "$TENANT" = "tsuzumi" ]; then
             PORT=3002
           else
             PORT=3000
@@ -254,9 +254,9 @@ jobs:
             if [ "$TENANT" = "fasthelp" ]; then
               PORT=3001
               NEXT_PUBLIC_BASE_PATH="/fasthelp/dashboard"
-            elif [ "$TENANT" = "tusuzumi" ]; then
+            elif [ "$TENANT" = "tsuzumi" ]; then
               PORT=3002
-              NEXT_PUBLIC_BASE_PATH="/tusuzumi/dashboard"
+              NEXT_PUBLIC_BASE_PATH="/tsuzumi/dashboard"
             else
               PORT=3000
               NEXT_PUBLIC_BASE_PATH="/dashboard"
@@ -298,7 +298,7 @@ jobs:
             echo "🧹 Cleaning up images from other tenants..."
 
             # Define all tenant options
-            ALL_TENANTS=("default" "fasthelp" "tusuzumi")
+            ALL_TENANTS=("default" "fasthelp" "tsuzumi")
 
             # Get registry IP
             REGISTRY_IP=$(sudo docker inspect local-registry --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
@@ -353,7 +353,7 @@ jobs:
             TENANT="${{ github.event.inputs.tenant }}"
             if [ "$TENANT" = "fasthelp" ]; then
               PORT=3001
-            elif [ "$TENANT" = "tusuzumi" ]; then
+            elif [ "$TENANT" = "tsuzumi" ]; then
               PORT=3002
             else
               PORT=3000
@@ -396,9 +396,9 @@ jobs:
                 if [ "$TENANT" = "fasthelp" ]; then
                   ROLLBACK_PORT=3001
                   ROLLBACK_BASE_PATH="/fasthelp/dashboard"
-                elif [ "$TENANT" = "tusuzumi" ]; then
+                elif [ "$TENANT" = "tsuzumi" ]; then
                   ROLLBACK_PORT=3002
-                  ROLLBACK_BASE_PATH="/tusuzumi/dashboard"
+                  ROLLBACK_BASE_PATH="/tsuzumi/dashboard"
                 else
                   ROLLBACK_PORT=3000
                   ROLLBACK_BASE_PATH="/dashboard"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -291,8 +291,34 @@ jobs:
             echo "🔍 Safe environment variables in container:"
             sudo docker exec mastra-test-dashboard env | grep -E "^(LOG_LEVEL|NEXT_PUBLIC_|NODE_ENV|ENABLE_)" | sort || echo "No safe env vars found"
 
-            # Clean up old images (keep running container image)
-            sudo docker images "*mastra-test-dashboard*" --format "{{.ID}} {{.CreatedAt}}" | sort -k2 -r | tail -n +3 | awk '{print $1}' | xargs -r sudo docker rmi || true
+            # Clean up other tenant images and keep only current tenant images
+            TENANT="${{ github.event.inputs.tenant }}"
+            ENV_FILE="${{ github.event.inputs.environment }}"
+
+            echo "🧹 Cleaning up images from other tenants..."
+
+            # Define all tenant options
+            ALL_TENANTS=("default" "fasthelp" "tusuzumi")
+
+            # Get registry IP
+            REGISTRY_IP=$(sudo docker inspect local-registry --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+
+            # Remove images from other tenants (both local and registry images)
+            for tenant in "${ALL_TENANTS[@]}"; do
+              if [ "$tenant" != "$TENANT" ]; then
+                echo "🗑️ Removing images for tenant: $tenant"
+
+                # Remove local images for other tenants
+                sudo docker images | grep "mastra-test-dashboard" | grep -v "$REGISTRY_IP:5000" | awk '{print $3}' | xargs -r sudo docker rmi -f 2>/dev/null || true
+
+                # Remove registry images for other tenants
+                sudo docker rmi -f "$REGISTRY_IP:5000/mastra-test-dashboard:$ENV_FILE-latest-$tenant" 2>/dev/null || true
+              fi
+            done
+
+            # Clean up old images for current tenant (keep latest 2)
+            echo "🧹 Cleaning up old images for current tenant: $TENANT"
+            sudo docker images "$REGISTRY_IP:5000/mastra-test-dashboard" --format "{{.ID}} {{.CreatedAt}}" | sort -k2 -r | tail -n +3 | awk '{print $1}' | xargs -r sudo docker rmi || true
 
             echo "✅ Application deployed successfully"
           EOF


### PR DESCRIPTION
## Summary
- Add tenant ID to Docker build arguments and environment variables
- Implement cleanup logic to remove Docker images from other tenants
- Update health checks to use tenant-specific ports (3000/3001/3002)
- Improve rollback configuration with proper tenant settings
- Rename tenant from tusuzumi to tsuzumi

## Changes

### Docker & Deployment
- **Dockerfile**: Added `TENANT_ID` build arg and environment variable
- **deploy.yml**: 
  - Added `--build-arg TENANT_ID=$TENANT` to Docker build command
  - Implemented cleanup logic to remove images from inactive tenants
  - Updated health check to detect tenant and use correct port
  - Enhanced rollback section with tenant-specific port and base path configuration
  - Renamed tenant from "tusuzumi" to "tsuzumi" throughout

### Tenant Configuration
- **default**: Port 3000, Base path `/dashboard`
- **fasthelp**: Port 3001, Base path `/fasthelp/dashboard`
- **tsuzumi**: Port 3002, Base path `/tsuzumi/dashboard`

## Benefits
- Better disk space management by cleaning up unused tenant images
- Proper tenant isolation with dedicated build arguments
- Correct port mapping for each tenant during deployment and rollback
- Improved deployment reliability with tenant-aware health checks

## Test plan
- [ ] Verify Docker build accepts TENANT_ID build argument
- [ ] Test deployment for all three tenants (default, fasthelp, tsuzumi)
- [ ] Verify cleanup logic removes images from other tenants
- [ ] Test health checks work on tenant-specific ports
- [ ] Verify deployment rollback uses correct tenant configuration
- [ ] Ensure container environment includes TENANT_ID variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>